### PR TITLE
Feat: button/floating 구현

### DIFF
--- a/src/components/common/ButtonFloating/ButtonFloating.jsx
+++ b/src/components/common/ButtonFloating/ButtonFloating.jsx
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import styles from './ButtonFloating.module.css';
+
+export default function ButtonFloating({ onClick, type }) {
+  const [buttonText, setButtonText] = useState('');
+
+  useEffect(() => {
+    const handleResize = () => {
+      const changeButtonText =
+        type === 'questionButton' ? (window.innerWidth <= 375 ? '질문 작성' : '질문 작성하기') : '삭제하기';
+
+      setButtonText(changeButtonText);
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return (
+    <button className={`${styles[type]}`} onClick={onClick}>
+      {buttonText}
+    </button>
+  );
+}

--- a/src/components/common/ButtonFloating/ButtonFloating.jsx
+++ b/src/components/common/ButtonFloating/ButtonFloating.jsx
@@ -1,29 +1,9 @@
-import { useState, useEffect } from 'react';
 import styles from './ButtonFloating.module.css';
 
-export default function ButtonFloating({ onClick, type }) {
-  const [buttonText, setButtonText] = useState('');
-
-  useEffect(() => {
-    const handleResize = () => {
-      const changeButtonText =
-        type === 'question' ? (window.innerWidth <= 375 ? '질문 작성' : '질문 작성하기') : '삭제하기';
-
-      setButtonText(changeButtonText);
-    };
-
-    handleResize();
-
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, [type]);
-
+export default function ButtonFloating({ handleButtonClick }) {
   return (
-    <button className={`${styles.button} ${styles[type]}`} onClick={onClick}>
-      {buttonText}
+    <button className={styles.button} onClick={handleButtonClick}>
+      질문 작성하기
     </button>
   );
 }

--- a/src/components/common/ButtonFloating/ButtonFloating.jsx
+++ b/src/components/common/ButtonFloating/ButtonFloating.jsx
@@ -1,9 +1,9 @@
 import styles from './ButtonFloating.module.css';
 
-export default function ButtonFloating({ handleButtonClick }) {
+export default function ButtonFloating({ handleButtonClick, text }) {
   return (
     <button className={styles.button} onClick={handleButtonClick}>
-      질문 작성하기
+      {text}
     </button>
   );
 }

--- a/src/components/common/ButtonFloating/ButtonFloating.jsx
+++ b/src/components/common/ButtonFloating/ButtonFloating.jsx
@@ -7,7 +7,7 @@ export default function ButtonFloating({ onClick, type }) {
   useEffect(() => {
     const handleResize = () => {
       const changeButtonText =
-        type === 'questionButton' ? (window.innerWidth <= 375 ? '질문 작성' : '질문 작성하기') : '삭제하기';
+        type === 'question' ? (window.innerWidth <= 375 ? '질문 작성' : '질문 작성하기') : '삭제하기';
 
       setButtonText(changeButtonText);
     };
@@ -19,10 +19,10 @@ export default function ButtonFloating({ onClick, type }) {
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, []);
+  }, [type]);
 
   return (
-    <button className={`${styles[type]}`} onClick={onClick}>
+    <button className={`${styles.button} ${styles[type]}`} onClick={onClick}>
       {buttonText}
     </button>
   );

--- a/src/components/common/ButtonFloating/ButtonFloating.module.css
+++ b/src/components/common/ButtonFloating/ButtonFloating.module.css
@@ -1,33 +1,13 @@
 .button {
+  width: 20.8rem;
+  height: 5.4rem;
   padding: 1.2rem 2.4rem;
   border: none;
   border-radius: 20rem;
   background: var(--color-border-focusing);
   box-shadow: var(--box-shadow-2pt);
   color: var(--color-background-primary);
-  flex-shrink: 0;
-}
-
-.questionButton {
-  width: 20.8rem;
-  height: 5.4rem;
   font-family: Actor;
   font-size: var(--font-size-20);
-
-  @media (max-width: 375px) {
-    width: auto;
-    font-family: Pretendard;
-  }
-}
-
-.deleteButton {
-  width: auto;
-  height: auto;
-  font-family: Pretendard;
-  font-size: 1.5rem;
-
-  @media (max-width: 375px) {
-    padding: 0.8rem 1.7rem;
-    font-size: 1rem;
-  }
+  flex-shrink: 0;
 }

--- a/src/components/common/ButtonFloating/ButtonFloating.module.css
+++ b/src/components/common/ButtonFloating/ButtonFloating.module.css
@@ -1,0 +1,37 @@
+.questionButton {
+  width: 20.8rem;
+  height: 5.4rem;
+  padding: 1.2rem 2.4rem;
+  border: none;
+  border-radius: 20rem;
+  background: #542f1a;
+  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
+  color: #fff;
+  font-family: Actor;
+  font-size: 2rem;
+  flex-shrink: 0;
+
+  @media (max-width: 375px) {
+    width: auto;
+    font-family: Pretendard;
+  }
+}
+
+.deleteButton {
+  width: auto;
+  height: auto;
+  padding: 1.2rem 2.4rem;
+  border: none;
+  border-radius: 20rem;
+  background: #542f1a;
+  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
+  color: #fff;
+  font-family: Pretendard;
+  font-size: 1.5rem;
+  flex-shrink: 0;
+
+  @media (max-width: 375px) {
+    padding: 0.8rem 1.7rem;
+    font-size: 1rem;
+  }
+}

--- a/src/components/common/ButtonFloating/ButtonFloating.module.css
+++ b/src/components/common/ButtonFloating/ButtonFloating.module.css
@@ -1,15 +1,18 @@
-.questionButton {
-  width: 20.8rem;
-  height: 5.4rem;
+.button {
   padding: 1.2rem 2.4rem;
   border: none;
   border-radius: 20rem;
-  background: #542f1a;
-  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
-  color: #fff;
-  font-family: Actor;
-  font-size: 2rem;
+  background: var(--color-border-focusing);
+  box-shadow: var(--box-shadow-2pt);
+  color: var(--color-background-primary);
   flex-shrink: 0;
+}
+
+.questionButton {
+  width: 20.8rem;
+  height: 5.4rem;
+  font-family: Actor;
+  font-size: var(--font-size-20);
 
   @media (max-width: 375px) {
     width: auto;
@@ -20,15 +23,8 @@
 .deleteButton {
   width: auto;
   height: auto;
-  padding: 1.2rem 2.4rem;
-  border: none;
-  border-radius: 20rem;
-  background: #542f1a;
-  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
-  color: #fff;
   font-family: Pretendard;
   font-size: 1.5rem;
-  flex-shrink: 0;
 
   @media (max-width: 375px) {
     padding: 0.8rem 1.7rem;


### PR DESCRIPTION
## 주요 변경 사항
- 질문 작성하기 및 삭제하기 버튼을 공용 컴포넌트로 구현

## 스크린샷
- Pc & Tablet 사이즈
![1](https://github.com/SprintPart2Team10/openmind/assets/140484169/585f08e9-54ae-48fa-9097-bda5408083f7)
- Mobile(375px 이하) 사이즈
![2](https://github.com/SprintPart2Team10/openmind/assets/140484169/e55e72ae-b31a-45e7-be1c-7a4305b0478e) 
- Pc & Tablet 사이즈
![3](https://github.com/SprintPart2Team10/openmind/assets/140484169/bca1493f-c447-4bea-9ea7-6d8aaa992476)
- Mobile(375px 이하) 사이즈
![4](https://github.com/SprintPart2Team10/openmind/assets/140484169/e1159045-b445-46e3-b604-0d88475fd83e)

## 설명
이 컴포넌트는 onClick과 type을 prop으로 받아서 동작합니다
`<ButtonFloating onClick={onClick} type='className' />` 

- onClick의 경우
post/{id} 페이지에서는 질문을 작성하는 모달창을 띄우는 함수를
post/{id}/answer 페이지에서는 받은 답변을 삭제하는 함수를 만들어서 넣어주시면 됩니다.

- type의 경우
아래와 같이 컴포넌트의 type prop의 값으로 question 이나 delete이라는 className을 넣어서 사용하시면 됩니다.
post/{id} 페이지에서는 `<ButtonFloating type='question' />`
post/{id}/answer 페이지에서는 `<ButtonFloating type='delete' />`

추가로 피그마를 보면 각각의 페이지에서 해당 컴포넌트의 위치가 다르기 때문에 
post/{id} 페이지에서는 `display: absolute`와 `bottom`, `right `속성을 이용하고
post/{id}/answer 페이지에서는 `display: flex`와 `justify-content: flex-end`를 이용하여 배치하시면 될 거 같습니다.

## 팀원에게

