### PR TITLE
Feat: Reaction 구현

### DIFF
--- a/src/components/Reaction/Reaction.jsx
+++ b/src/components/Reaction/Reaction.jsx
@@ -2,17 +2,17 @@ import thumbsUp from '../../assets/icons/thumbsUp.svg';
 import thumbsDown from '../../assets/icons/thumbsDown.svg';
 import styles from './Reaction.module.css';
 
-export default function Reaction({ onClick, like, dislike }) {
+export default function Reaction({ handleButtonClick, like, dislike }) {
   const likeStatus = like === 0 ? `좋아요` : `좋아요 ${like}`;
   const dislikeStatus = dislike === 0 ? `싫어요` : `싫어요 ${dislike}`;
 
   return (
     <div className={styles.reaction}>
-      <button className={styles.like} onClick={onClick}>
+      <button className={styles.like} onClick={handleButtonClick}>
         <img src={thumbsUp} alt='thumbsUp' />
         {likeStatus}
       </button>
-      <button className={styles.dislike} onClick={onClick}>
+      <button className={styles.dislike} onClick={handleButtonClick}>
         <img src={thumbsDown} alt='thumbsDown' />
         {dislikeStatus}
       </button>

--- a/src/components/Reaction/Reaction.jsx
+++ b/src/components/Reaction/Reaction.jsx
@@ -8,12 +8,12 @@ export default function Reaction({ handleButtonClick, like, dislike }) {
 
   return (
     <div className={styles.reaction}>
-      <button className={styles.like} onClick={handleButtonClick}>
-        <img src={thumbsUp} alt='thumbsUp' />
+      <button className={styles.button} onClick={handleButtonClick}>
+        <img className={styles.img} src={thumbsUp} alt='thumbsUp' />
         {likeStatus}
       </button>
-      <button className={styles.dislike} onClick={handleButtonClick}>
-        <img src={thumbsDown} alt='thumbsDown' />
+      <button className={styles.button} onClick={handleButtonClick}>
+        <img className={styles.img} src={thumbsDown} alt='thumbsDown' />
         {dislikeStatus}
       </button>
     </div>

--- a/src/components/Reaction/Reaction.jsx
+++ b/src/components/Reaction/Reaction.jsx
@@ -3,8 +3,8 @@ import thumbsDown from '../../assets/icons/thumbsDown.svg';
 import styles from './Reaction.module.css';
 
 export default function Reaction({ handleButtonClick, like, dislike }) {
-  const likeStatus = like === 0 ? `좋아요` : `좋아요 ${like}`;
-  const dislikeStatus = dislike === 0 ? `싫어요` : `싫어요 ${dislike}`;
+  const likeStatus = `좋아요 ${like === 0 ? '' : like}`;
+  const dislikeStatus = `싫어요 ${dislike === 0 ? '' : dislike}`;
 
   return (
     <div className={styles.reaction}>

--- a/src/components/Reaction/Reaction.jsx
+++ b/src/components/Reaction/Reaction.jsx
@@ -1,0 +1,21 @@
+import thumbsUp from '../../assets/icons/thumbsUp.svg';
+import thumbsDown from '../../assets/icons/thumbsDown.svg';
+import styles from './Reaction.module.css';
+
+export default function Reaction({ onClick, like, dislike }) {
+  const likeStatus = like === 0 ? `좋아요` : `좋아요 ${like}`;
+  const dislikeStatus = dislike === 0 ? `싫어요` : `싫어요 ${dislike}`;
+
+  return (
+    <div className={styles.reaction}>
+      <button className={styles.like} onClick={onClick}>
+        <img src={thumbsUp} alt='thumbsUp' />
+        {likeStatus}
+      </button>
+      <button className={styles.dislike} onClick={onClick}>
+        <img src={thumbsDown} alt='thumbsDown' />
+        {dislikeStatus}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Reaction/Reaction.module.css
+++ b/src/components/Reaction/Reaction.module.css
@@ -1,0 +1,26 @@
+.reaction {
+  display: flex;
+  gap: 3.2rem;
+  font-size: var(--font-size-14);
+}
+
+.reaction button {
+  display: flex;
+  gap: 0.6rem;
+  color: var(--color-text-secondary);
+  filter: invert(55%) sepia(3%) saturate(7%) hue-rotate(358deg) brightness(92%) contrast(89%);
+  font-family: Pretendard;
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.8rem;
+}
+
+.reaction button:hover {
+  color: var(--color-text-primary);
+  filter: invert(0%) sepia(3%) saturate(0%) hue-rotate(287deg) brightness(102%) contrast(100%);
+}
+
+.reaction img {
+  width: 1.6rem;
+  height: 1.6rem;
+}

--- a/src/components/Reaction/Reaction.module.css
+++ b/src/components/Reaction/Reaction.module.css
@@ -4,7 +4,7 @@
   font-size: var(--font-size-14);
 }
 
-.reaction button {
+.button {
   display: flex;
   gap: 0.6rem;
   color: var(--color-text-secondary);
@@ -15,12 +15,12 @@
   line-height: 1.8rem;
 }
 
-.reaction button:hover {
+.button:hover {
   color: var(--color-text-primary);
   filter: invert(0%) sepia(3%) saturate(0%) hue-rotate(287deg) brightness(102%) contrast(100%);
 }
 
-.reaction img {
+.img {
   width: 1.6rem;
   height: 1.6rem;
 }

--- a/src/components/Reaction/Reaction.module.css
+++ b/src/components/Reaction/Reaction.module.css
@@ -9,7 +9,6 @@
   gap: 0.6rem;
   color: var(--color-text-secondary);
   filter: invert(55%) sepia(3%) saturate(7%) hue-rotate(358deg) brightness(92%) contrast(89%);
-  font-family: Pretendard;
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-medium);
   line-height: 1.8rem;


### PR DESCRIPTION
## 주요 변경 사항
- Reaction 버튼을 공용 컴포넌트로 구현

## 스크린샷
- 기본 상태
![1](https://github.com/SprintPart2Team10/openmind/assets/140484169/ec71b322-c7b0-4bfe-a52e-684c7c28d7c6)
- mouseover 상태
![2](https://github.com/SprintPart2Team10/openmind/assets/140484169/519dcd25-63d1-4636-a2cf-2d547f74ecfa)
![3](https://github.com/SprintPart2Team10/openmind/assets/140484169/72364be5-4e44-4d24-9871-70576eec3114)

## 설명
기본 상태와 마우스를 해당 버튼에 올린 상태로 구현했습니다.
해당 버튼이 클릭될 때 onClick prop의 값으로 들어갈 함수를 통해 받아온 객체 데이터에서
like와 dislike을 값을 prop으로 내려주면 해당 값을 받아서 표시해 줄 수 있게 했습니다.
해당 값이 0일 경우에는 숫자를 표시하지 않게 했고 해당 값이 0이 아닐 경우에는 숫자도 표시하도록 구현했습니다.

피그마를 보면 좋아요/싫어요 버튼이 이미 클릭된 상태는 파란색으로 표시가 되는데 
이 부분은 실제로 동작했을 때에 변화이기 때문에 구현하지 않았습니다.

이 컴포넌트를 사용하실 때
해당 버튼을 클릭 시 동작하는 함수를 만들어 onClick prop의 값으로 넣어주시면 되는데 
이때 Reaction.module.css 파일에서 className을 하나 만들어 `color: var(--color-text-selected);` 속성을 작성하고 
함수가 해당 className을 추가하도록 만들어서 사용하시면 될 거 같습니다.


## 팀원에게
images 폴더에 SVG 파일들 중 기본 색상이 검은색인 파일들이 있습니다.
다른 색을 사용해야 할 때 SVG 파일에 색을 넣어줘서 사용하시면 되는데
팀 notion의 공유 탭에 SVG 파일 색상 적용이라는 게 있습니다.
아마 채연님이 올려주신 거 같은데 해당 사이트에서 원하는 색상 값을 넣어주고 Compute Filters를 누르면
아래의 사진과 같이 
`filter: invert(42%) sepia(100%) saturate(1822%) hue-rotate(163deg) brightness(97%) contrast(101%);` 값이 나옵니다.
이걸 사용하시면 SVG 파일 색상을 변경할 수 있습니다.
저도 덕분에 쉽게 해결했습니다.
![image](https://github.com/SprintPart2Team10/openmind/assets/140484169/693edde4-893f-4445-8ff3-90b83fb975fb)

