### PR TITLE
Feat: badge 구현

### DIFF
--- a/src/components/common/Badge/Badge.jsx
+++ b/src/components/common/Badge/Badge.jsx
@@ -1,0 +1,5 @@
+import styles from './Badge.module.css';
+
+export default function Badge({ className, text }) {
+  return <div className={`${styles.badge} ${styles[`${className}`]}`}>{text}</div>;
+}

--- a/src/components/common/Badge/Badge.module.css
+++ b/src/components/common/Badge/Badge.module.css
@@ -1,0 +1,18 @@
+.badge {
+  display: inline-flex;
+  padding: 0.4rem 1.2rem;
+  border-radius: 0.8rem;
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.8rem;
+}
+
+.active {
+  color: var(--color-brown-40);
+  border: 1px solid var(--color-border-focusing);
+}
+
+.inActive {
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-primary);
+}


### PR DESCRIPTION
### 주요 구현 사항
- 답변 완료, 미답변 여부를 나타내는 badge UI 구현

### 스크린샷
![image](https://github.com/SprintPart2Team10/openmind/assets/141597336/1e22ae86-6718-407c-bd98-0783b404f2a1)

### 구체적 구현사항 설명
- "답변 완료" "미답변"과 같이 표시할 내용을 text prop으로 받고, css를 위해 className을 prop으로 받아 나타냅니다.
- 실사용 예시
- `<Badge className='active' text='답변 완료' />`
- `<Badge className='inActive' text='미답변' />`

### 논의 사항
- 클래스이름을 active, inActive로 작성했는데, done, yet 정도가 더 나은가 하는 생각이 드네요.
- 컴포넌트의 display를 inline-flex로 했는데, 적절할까요?
- 이 컴포넌트같은 경우에는 재사용성에 대한 고민이 좀 많습니다. 서로 다른 페이지에서 다른 형태로 사용될 가능성이 매우 낮고, "답변 완료" "미답변" 형태로만 사용될 가능성이 많아서요. 이 컴포넌트 구현에 대해 좀 더 적합한 아이디어가 있을까요?


