### PR TITLE
Feat: Dropdown 케밥 컴포넌트 구현

### DIFF
--- a/src/components/common/DropdownKebab/DropdownKebab.jsx
+++ b/src/components/common/DropdownKebab/DropdownKebab.jsx
@@ -3,9 +3,9 @@ import more from '../../../images/icons/more.svg';
 import editImage from '../../../images/icons/edit.svg';
 import styles from './DropdownKebab.module.css';
 
-export default function DropdownKebab({ List, handleButtonClick }) {
+export default function DropdownKebab({ list, handleButtonClick }) {
   const [isDropdownView, setDropdownView] = useState(false);
-
+  const setTime = 200;
   const handleClickContainer = () => {
     setDropdownView(!isDropdownView);
   };
@@ -13,19 +13,17 @@ export default function DropdownKebab({ List, handleButtonClick }) {
   const handleBlurContainer = () => {
     setTimeout(() => {
       setDropdownView(false);
-    }, 200);
+    }, setTime);
   };
 
   return (
     <div onBlur={handleBlurContainer} className={styles.kebabBox}>
-      <label onClick={handleClickContainer}>
-        <button>
-          <img src={more} alt='케밥버튼 이미지' />
-        </button>
-      </label>
+      <button onClick={handleClickContainer}>
+        <img src={more} alt='케밥버튼 이미지' />
+      </button>
       {isDropdownView && (
         <ul className={styles.buttonList}>
-          {List.map((buttonName) => (
+          {list.map((buttonName) => (
             <li className={styles.button} key={buttonName} onClick={handleButtonClick}>
               <img className={styles.buttonImage} src={editImage} alt='수정버튼 이미지' />
               {buttonName}

--- a/src/components/common/DropdownKebab/DropdownKebab.jsx
+++ b/src/components/common/DropdownKebab/DropdownKebab.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import more from '../../../images/icons/more.svg';
+import editImage from '../../../images/icons/edit.svg';
+import styles from './DropdownKebab.module.css';
+
+export default function DropdownKebab({ List, handleButtonClick }) {
+  const [isDropdownView, setDropdownView] = useState(false);
+
+  const handleClickContainer = () => {
+    setDropdownView(!isDropdownView);
+  };
+
+  const handleBlurContainer = () => {
+    setTimeout(() => {
+      setDropdownView(false);
+    }, 200);
+  };
+
+  return (
+    <div onBlur={handleBlurContainer} className={styles.kebabBox}>
+      <label onClick={handleClickContainer}>
+        <button>
+          <img src={more} alt='케밥버튼 이미지' />
+        </button>
+      </label>
+      {isDropdownView && (
+        <ul className={styles.buttonList}>
+          {List.map((buttonName) => (
+            <li className={styles.button} key={buttonName} onClick={handleButtonClick}>
+              <img className={styles.buttonImage} src={editImage} alt='수정버튼 이미지' />
+              {buttonName}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/DropdownKebab/DropdownKebab.module.css
+++ b/src/components/common/DropdownKebab/DropdownKebab.module.css
@@ -1,0 +1,49 @@
+.kebabBox {
+  display: flex;
+  position: relative;
+}
+
+.buttonList {
+  list-style-type: none;
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  padding: 0.4px 0rem;
+  bottom: -9rem;
+  border-radius: 0.8rem;
+  border: 0.1rem solid var(--color-gray-30);
+  box-shadow: var(--box-shadow-1pt);
+}
+
+.button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.6rem 1.6rem;
+  gap: 0.8rem;
+  color: var(--color-gray-50);
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+.buttonImage {
+  filter: invert(32%) sepia(0%) saturate(2901%) hue-rotate(149deg) brightness(91%) contrast(85%);
+  width: var(--font-size-14);
+}
+
+.button:hover {
+  color: var(--color-gray-60);
+  background: var(--color-gray-20);
+  background-clip: content-box;
+  .buttonImage {
+    filter: none;
+  }
+}
+
+.button:active {
+  color: var(--color-blue-50);
+  .buttonImage {
+    filter: invert(38%) sepia(96%) saturate(3474%) hue-rotate(202deg) brightness(98%) contrast(94%);
+  }
+}

--- a/src/components/common/DropdownKebab/DropdownKebab.module.css
+++ b/src/components/common/DropdownKebab/DropdownKebab.module.css
@@ -43,6 +43,8 @@
 
 .button:active {
   color: var(--color-blue-50);
+  background: var(--color-gray-10);
+  background-clip: content-box;
   .buttonImage {
     filter: invert(38%) sepia(96%) saturate(3474%) hue-rotate(202deg) brightness(98%) contrast(94%);
   }


### PR DESCRIPTION
## 주요 변경 사항

- 드롭다운 메뉴 중 수정하기 버튼이 표시되는 케밥 컴포넌트 구현

## 스크린샷
![케밥](https://github.com/SprintPart2Team10/openmind/assets/148832721/b3caffa7-96aa-4510-a464-b908b673d1ec)
![케밥](https://github.com/SprintPart2Team10/openmind/assets/148832721/165883df-5c6d-4106-a5cc-2a6410b13460)
## 구체적 구현사항 설명
- DropdownKebab컴포넌트에서는  List, handleButtonClick 2개의 props 를 받습니다. 
- 사용 예시 
```
const ButtonList = ['수정하기', '삭제하기'];
<DropdownKebab List={ButtonList} handleButtonClick={Click} />
```

## 막혔던 점, 궁금했던 점, 다른 팀원에게 논의하고 싶은 점 작성
- svg이미지와 버튼 텍스트에 hover 효과를 같이 주는 방법을 몰라서 한참 헤맸는데, 
```
.button:hover {
  color: var(--color-gray-60);
  background: var(--color-gray-20);
  background-clip: content-box;
  .buttonImage {
    filter: none; 
  }
}
```
가상 클래스안에 이미지 클래스를 작성하는 방법으로 해결하였습니다. 

- 수정하기 버튼에 마우스를 hover하였을 때 적용되는 배경 색이 박스 외부로 튀어나오는 문제가있었는데,
  `background-clip: content-box;` 로 적용하여 해결하였습니다.
