### PR TITLE
Feat : 답변 컴포넌트 구현

### DIFF
--- a/src/components/common/FeedCardAnswer/Answer/Answer.jsx
+++ b/src/components/common/FeedCardAnswer/Answer/Answer.jsx
@@ -1,0 +1,5 @@
+import styles from './Answer.module.css';
+
+export default function Answer({ content, isRejected }) {
+  return <>{isRejected ? <p className={styles.accept}>{content}</p> : <p className={styles.reject}>답변 거절</p>}</>;
+}

--- a/src/components/common/FeedCardAnswer/Answer/Answer.module.css
+++ b/src/components/common/FeedCardAnswer/Answer/Answer.module.css
@@ -1,0 +1,11 @@
+.accept {
+  color: var(--color-gray-60);
+  font-size: var(--font-size-16);
+  font-weight: var(--font-weight-regular);
+}
+
+.reject {
+  color: var(--color-red-50);
+  font-size: var(--font-size-16);
+  font-weight: var(--font-weight-regular);
+}

--- a/src/components/common/FeedCardAnswer/AnswerLayout/AnswerLayout.jsx
+++ b/src/components/common/FeedCardAnswer/AnswerLayout/AnswerLayout.jsx
@@ -1,0 +1,16 @@
+import styles from './AnswerLayout.module.css';
+
+export default function AnswerLayout({ children, createdAt, name, imageSource, alt, answer }) {
+  return (
+    <div className={styles.wrap}>
+      <img className={styles.profileImage} src={imageSource} alt={alt} />
+      <div className={styles.answerWrap}>
+        <div className={styles.nameWrap}>
+          <span className={styles.name}>{name}</span>
+          {answer && <span className={styles.createdAt}>{createdAt}</span>}
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/FeedCardAnswer/AnswerLayout/AnswerLayout.module.css
+++ b/src/components/common/FeedCardAnswer/AnswerLayout/AnswerLayout.module.css
@@ -1,0 +1,49 @@
+.wrap {
+  display: flex;
+  column-gap: 1.2rem;
+  width: 59.2rem;
+  margin-top: 2rem;
+  margin-left: 2rem;
+}
+
+.nameWrap {
+  display: flex;
+  align-items: center;
+  column-gap: 0.8rem;
+}
+
+.name {
+  color: var(--color-gray-60);
+  font-size: var(--font-size-18);
+  font-family: Actor;
+  font-weight: var(--font-weight-regular);
+}
+
+.profileImage {
+  width: 4.8rem;
+  height: 4.8rem;
+}
+
+.answerWrap {
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.4rem;
+  width: 100%;
+  max-width: 53.2rem;
+}
+
+.createdAt {
+  color: var(--color-gray-40);
+  font-size: var(--font-size-14);
+  font-weight: var(--font-weight-medium);
+}
+
+@media screen and (max-width: 375px) {
+  .profileImage {
+    width: 3.2rem;
+    height: 3.2rem;
+  }
+  .name {
+    font-size: var(--font-size-14);
+  }
+}

--- a/src/components/common/FeedCardAnswer/AnswerTextArea/AnswerTextArea.jsx
+++ b/src/components/common/FeedCardAnswer/AnswerTextArea/AnswerTextArea.jsx
@@ -1,0 +1,20 @@
+import styles from './AnswerTextArea.module.css';
+
+export default function AnswerTextArea({ content, placeholder }) {
+  return (
+    <form>
+      <textarea
+        className={styles.textArea}
+        name=''
+        id=''
+        cols='30'
+        rows='10'
+        placeholder={placeholder}
+        // value={content}
+      ></textarea>
+      <button type='submit' className={styles.button}>
+        답변 완료
+      </button>
+    </form>
+  );
+}

--- a/src/components/common/FeedCardAnswer/AnswerTextArea/AnswerTextArea.module.css
+++ b/src/components/common/FeedCardAnswer/AnswerTextArea/AnswerTextArea.module.css
@@ -1,0 +1,22 @@
+.textArea {
+  width: 100%;
+  height: 100%;
+  max-height: 15.4rem;
+  padding: 1.6rem;
+  border-radius: 0.8rem;
+  background-color: var(--color-gray-20);
+  font-size: var(--font-size-16);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-gray-40);
+}
+
+.button {
+  width: 100%;
+  height: 4.6rem;
+  padding: 1.2rem 2.4rem;
+  border-radius: 0.8rem;
+  background-color: var(--color-brown-30);
+  font-size: var(--font-size-16);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-gray-10);
+}

--- a/src/pages/answer/AnswerPage.jsx
+++ b/src/pages/answer/AnswerPage.jsx
@@ -1,3 +1,32 @@
-export default function AnswerPage() {
-  return <div>일단 임시로 AnswerPage로 작명했습니다. 이후에 적절하게 바꿔주세요.</div>;
+import AnswerLayout from '../../components/common/FeedCardAnswer/AnswerLayout/AnswerLayout';
+import Answer from '../../components/common/FeedCardAnswer/Answer/Answer';
+import AnswerTextArea from '../../components/common/FeedCardAnswer/AnswerTextArea/AnswerTextArea';
+
+// 테스트
+export default function AnswerPage({
+  // answer -> GET /answers/{answerId}/
+  id,
+  content = '그들을 불러 귀는 이상의 오직 피고,',
+  isRejected = 'false',
+  createdAt = '2주전',
+  placeholder = '답변을 입력해주세요',
+
+  // subject -> GET /subjects/{subjectId}/
+  subjectId,
+  name = '아초는고양이',
+  imageSource = '/src/images/profile.svg',
+  alt = '사용자 이미지',
+
+  // question -> GET /{team}/questions/{id}/
+  answer,
+}) {
+  return (
+    <AnswerLayout createdAt={createdAt} name={name} imageSource={imageSource} alt={alt} answer={answer}>
+      {answer ? (
+        <Answer content={content} isRejected={isRejected} />
+      ) : (
+        <AnswerTextArea content={content} placeholder={placeholder} />
+      )}
+    </AnswerLayout>
+  );
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,19 +27,3 @@ button {
   border: 0;
   cursor: pointer;
 }
-
-p {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-}
-
-textarea {
-  font-family: inherit;
-  font-size: 100%;
-  line-height: 1.15;
-  margin: 0;
-}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,3 +27,19 @@ button {
   border: 0;
   cursor: pointer;
 }
+
+p {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}


### PR DESCRIPTION
### 주요 변경 사항
- 답변 컴포넌트 layout, css구현

### 스크린샷
- 피그마
![image](https://github.com/SprintPart2Team10/openmind/assets/43229599/c35b3d6d-f2f3-4cc4-a9d1-1fce1ed48b0d)

- 개인
답변이 없는 경우
![image](https://github.com/SprintPart2Team10/openmind/assets/43229599/0306859c-02fe-42a4-9250-bcca65195f60)
답변이 있는 경우
![image](https://github.com/SprintPart2Team10/openmind/assets/43229599/634b2d24-471d-4e3e-9254-438070dd3610)
답변이 있는 경우(답변 거절)
![image](https://github.com/SprintPart2Team10/openmind/assets/43229599/ca652dd1-b09d-4bdf-b519-fe3018db74e2)

### 구체적 구현사항 설명
- AnswerLayout: answer, answerTextarea와 동일하게 사용되는 Layout 컴포넌트
- AnswerTextarea : 답변을 작성해야 할 때 보여줄 컴포넌트
- Answer : 답변이 있는 경우 보여줄 컴포넌트

### 다른 팀원에게 논의하고 싶은 점
- p태그와 textarea css를 초기화해야하는 경우가 생겨서 global.css에 추가했고
따로 PR을 분리하기에는 번거로운거같아서 같이 PR을 올렸는데 global.css초기화를 잘못시켜 다시 원복시켜두었습니다
다음에 같은 상황일 떄 필요 시에 global.css에 내용 추가 해두면 될까요?