### PR TITLE
Refactor: 버튼 박스 컴포넌트 수정

### DIFF
--- a/src/components/common/ButtonBox/ButtonBox.jsx
+++ b/src/components/common/ButtonBox/ButtonBox.jsx
@@ -1,11 +1,5 @@
 import styles from './ButtonBox.module.css';
 
-export default function ButtonBox({ handleButtonClick, children, className }) {
-  return (
-    <div>
-      <button className={styles[`${className}`]} onClick={handleButtonClick}>
-        {children}
-      </button>
-    </div>
-  );
+export default function ButtonBox({ children, className }) {
+  return <button className={`${styles.button} ${styles[`${className}`]}`}>{children}</button>;
 }

--- a/src/components/common/ButtonBox/ButtonBox.jsx
+++ b/src/components/common/ButtonBox/ButtonBox.jsx
@@ -1,5 +1,13 @@
 import styles from './ButtonBox.module.css';
 
-export default function ButtonBox({ children, className }) {
-  return <button className={`${styles.button} ${styles[`${className}`]}`}>{children}</button>;
+export default function ButtonBox({ children, className, text = true, handleButtonClick }) {
+  return (
+    <button
+      className={`${styles.button} ${styles[`${className}`]}`}
+      disabled={text ? false : true}
+      onClick={handleButtonClick}
+    >
+      {children}
+    </button>
+  );
 }

--- a/src/components/common/ButtonBox/ButtonBox.module.css
+++ b/src/components/common/ButtonBox/ButtonBox.module.css
@@ -1,39 +1,42 @@
-.lightButton {
-  display: inline-flex;
-  gap: 0.8rem;
+.button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
   padding: 1.2rem 2.4rem;
-  color: var(--color-brown-40);
-  border: 0.1rem solid var(--color-brown-40);
   border-radius: 0.8rem;
-  background: var(--color-brown-10);
+  font-family: 'Actor', sans-serif;
   font-size: var(--font-size-16);
+  line-height: 2.2rem;
+}
+
+.lightButton {
+  outline: 0.1rem solid var(--color-brown-40);
+  color: var(--color-brown-40);
+  background: var(--color-brown-10);
 }
 
 .lightButton:hover {
-  border: 0.2rem solid var(--color-brown-40);
+  outline: 0.2rem solid var(--color-brown-40);
 }
 
 .lightButton:active {
-  border: 0.2rem solid var(--color-brown-40);
+  outline: 0.2rem solid var(--color-brown-40);
   background: var(--color-brown-20);
 }
 
 .lightButton:disabled {
-  border: 0.1rem solid var(--color-brown-30);
+  outline: 0.1rem solid var(--color-brown-30);
   color: var(--color-brown-30);
 }
 
 .darkButton {
-  display: inline-flex;
-  padding: 1.2rem 2.4rem;
   color: var(--color-gray-10);
-  border-radius: 0.8rem;
   background: var(--color-brown-40);
-  font-size: var(--font-size-16);
 }
 
 .darkButton:hover {
-  border: 0.2rem solid var(--color-brown-50);
+  outline: 0.2rem solid var(--color-brown-50);
 }
 
 .darkButton:active {
@@ -45,9 +48,10 @@
 }
 
 @media screen and (max-width: 375px) {
-  .lightButton,
-  .darkButton {
+  .button {
     height: 3.4rem;
     padding: 0.8rem 1.2rem;
+    font-size: var(--font-size-14);
+    line-height: 1.8rem;
   }
 }

--- a/src/components/common/ButtonBox/ButtonBox.module.css
+++ b/src/components/common/ButtonBox/ButtonBox.module.css
@@ -28,6 +28,7 @@
 .lightButton:disabled {
   outline: 0.1rem solid var(--color-brown-30);
   color: var(--color-brown-30);
+  background: var(--color-brown-10);
 }
 
 .darkButton {
@@ -44,6 +45,7 @@
 }
 
 .darkButton:disabled {
+  outline: none;
   background: var(--color-brown-30);
 }
 


### PR DESCRIPTION
### 수정사항

1. 버튼박스 컴포넌트를 form 태그 안에서 사용할 경우, form 태그 안의 input 혹은 textarea에 입력된 `text`가 있다면, 버튼을 활성화하고, 없다면 비활성화합니다.
2. 버튼박스 컴포넌트를 form 태그 안이 아니라, 별도로 버튼으로만 사용할 경우, onClick 이벤트를 받아 사용합니다.
3. css의 경우, 부모 태그의 width의 100% 상속합니다. 만약 크기 조정이 필요하다면 div태그로 한 단계 감싸 dIv 태그에 width를 지정하면 될 것 같습니다. 