### PR TITLE
Refactor : answer페이지 기능에 따른 렌더링

### DIFF
--- a/src/components/common/ButtonBox/ButtonBox.jsx
+++ b/src/components/common/ButtonBox/ButtonBox.jsx
@@ -1,6 +1,6 @@
 import styles from './ButtonBox.module.css';
 
-export default function ButtonBox({ children, className, text = true, handleButtonClick }) {
+export default function ButtonBox({ children, className, text, handleButtonClick }) {
   return (
     <button
       className={`${styles.button} ${styles[`${className}`]}`}

--- a/src/components/common/FeedCardAnswer/Answer.jsx
+++ b/src/components/common/FeedCardAnswer/Answer.jsx
@@ -5,16 +5,14 @@ import styles from './Answer.module.css';
 import { getElapsedTime } from '../../../utils/getElapsedTime';
 
 export default function Answer({
-  editCheck,
   answer,
   textareaValue,
   handleTextareaChange,
-  textareaClassName,
+  editCheck,
+  handleAnswerEdit,
   handleAnswerCreate,
 }) {
-  console.log(`editCheck?>>>>>>>>>>>>>>>>>`);
-  console.log(editCheck);
-  const { id, content, createdAt, questionId, isRejected } = answer || {};
+  const { content, createdAt, isRejected } = answer || {};
 
   const { id: subjectId, name, imageSource } = useContext(SubjectDataContext);
   const isId = localStorage.getItem('id') == subjectId;
@@ -33,19 +31,21 @@ export default function Answer({
         {answer ? (
           editCheck ? (
             <>
-              <textarea
-                className={styles.textarea}
-                name=''
-                id=''
-                cols='30'
-                rows='10'
-                placeholder='답변을 입력해주세요'
-                onInput={handleTextareaChange}
-                value={textareaValue}
-              ></textarea>
-              <ButtonBox className={textareaClassName} text={textareaValue} handleButtonClick={handleAnswerCreate}>
-                답변 완료
-              </ButtonBox>
+              <form onSubmit={handleAnswerEdit}>
+                <textarea
+                  className={styles.textarea}
+                  name=''
+                  id=''
+                  cols='30'
+                  rows='10'
+                  placeholder='답변을 입력해주세요'
+                  onInput={handleTextareaChange}
+                  value={textareaValue}
+                ></textarea>
+                <ButtonBox className='darkButton' text={textareaValue} handleButtonClick={handleAnswerEdit}>
+                  수정 완료
+                </ButtonBox>
+              </form>
             </>
           ) : isRejected ? (
             <p className={styles.reject}>답변 거절</p>
@@ -65,7 +65,7 @@ export default function Answer({
                 onInput={handleTextareaChange}
                 value={textareaValue}
               ></textarea>
-              <ButtonBox className={textareaClassName} text={textareaValue} handleButtonClick={handleAnswerCreate}>
+              <ButtonBox className='darkButton' text={textareaValue} handleButtonClick={handleAnswerCreate}>
                 답변 완료
               </ButtonBox>
             </form>

--- a/src/components/page-layout/QuestionPage/Layout/Header.module.css
+++ b/src/components/page-layout/QuestionPage/Layout/Header.module.css
@@ -20,6 +20,7 @@
   width: 100%;
   margin-top: 5rem;
   row-gap: 1.2rem;
+  z-index: 1;
 }
 
 .answerHeaderLogo {

--- a/src/components/page-layout/QuestionPage/Main/AnswerMain.jsx
+++ b/src/components/page-layout/QuestionPage/Main/AnswerMain.jsx
@@ -1,73 +1,77 @@
-import { useContext } from 'react';
-import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { SubjectDataContext } from '../../../../contexts/SubjectDataContext';
+import { useContext, useState } from 'react';
 import Answer from '../../../common/FeedCardAnswer/Answer.jsx';
-import ButtonFloating from '../../../common/ButtonFloating/ButtonFloating';
-import DropdownKebab from '../../../common/DropdownKebab/DropdownKebab';
 import { axiosBaseURL } from '../../../../apis/axiosBaseURL.js';
-import { useQuestionDelete } from '../../../../hooks/useQuestion.js';
+import { DataChangeDetectionContext } from '../../../../contexts/DataChangeDetectionContext.js';
 
-import styles from './AnswerMain.module.css';
+export default function AnswerMain({ editCheck, questionId, answer, setEditCheck }) {
+  const setDataChangeDetection = useContext(DataChangeDetectionContext);
 
-export default function AnswerMain({ questionId, answer }) {
-  console.log(`AnswerMain>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`);
-  console.log(questionId);
+  const { id: answerId, content } = answer || {};
 
-  const { id: subjectId } = useContext(SubjectDataContext);
-
-  const isId = localStorage.getItem('id') == subjectId;
-
-  const { id: answerId, content, createdAt, answerQuestionId, isRejected } = answer || {};
-  console.log(answer);
-
-  // textarea 입력 값
-  // const [textareaValue, setTextareaValue] = useState(answerData.content);
+  // textarea
   const [textareaValue, setTextareaValue] = useState(content);
   const handleTextareaChange = (e) => {
     setTextareaValue(e.target.value);
   };
 
-  // textarea 입력 시 버튼 클래스 변경
-  const [textareaClassName, setTextareaClassName] = useState('lightButton');
-  useEffect(() => {
-    setTextareaClassName('darkButton');
-  }, [textareaClassName]);
+  // 답변 하기
+  const handleAnswerCreate = async (e) => {
+    e.preventDefault();
 
-  // 전체 삭제 : api ?
-  const handleDeleteButton = async () => {
-    // api ?
+    try {
+      await axiosBaseURL.post(
+        `questions/${questionId}/answers/`,
+        {
+          content: textareaValue,
+          isRejected: false,
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      setDataChangeDetection(true);
+      setEditCheck(false);
+    } catch (error) {
+      console.log(`handleAnswerCreate Error : ${error}`);
+    }
   };
 
-  // 답변하기 : 수정이후 삭제 된 리스트를 새로 보여주는 기능 추가 필요
-  const handleAnswerCreate = async () => {
-    // 커스텀 훅으로 사용하고싶으나 405error발생 : 수정필요
-    // await useAnswerCreate(`questions/${questionId}/`,  );
-    await axiosBaseURL.post(
-      `questions/${questionId}/answers/`,
-      {
-        content: textareaValue,
-        isRejected: false,
-      },
-      {
-        headers: {
-          'Content-Type': 'application/json',
+  // 답변 수정하기
+  const handleAnswerEdit = async (e) => {
+    e.preventDefault();
+
+    try {
+      await axiosBaseURL.put(
+        `answers/${answerId}/`,
+        {
+          content: textareaValue,
+          isRejected: false,
         },
-      }
-    );
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      setDataChangeDetection(true);
+      setEditCheck(false);
+    } catch (error) {
+      console.log(`handleAnswerEdit Error : ${error}`);
+    }
   };
 
   return (
-    <>
-      {/* showAnswerForm 사용여부에 따라 textareaForm 표시 */}
-      <Answer
-        answer={answer}
-        textareaValue={textareaValue}
-        textareaClassName={textareaClassName}
-        handleTextareaChange={handleTextareaChange}
-        handleDeleteButton={handleDeleteButton}
-        handleAnswerCreate={handleAnswerCreate}
-      />
-    </>
+    // <>
+    <Answer
+      answer={answer}
+      textareaValue={textareaValue}
+      handleTextareaChange={handleTextareaChange}
+      editCheck={editCheck}
+      handleAnswerEdit={handleAnswerEdit}
+      handleAnswerCreate={handleAnswerCreate}
+    />
+    // </>
   );
 }

--- a/src/components/postpage/FeedCard/FeedCard.jsx
+++ b/src/components/postpage/FeedCard/FeedCard.jsx
@@ -1,10 +1,10 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import AnswerMain from '../../page-layout/QuestionPage/Main/AnswerMain';
 import Badge from '../../common/Badge/Badge';
 import DropdownKebab from '../../common/DropdownKebab/DropdownKebab';
 import Question from '../Question/Question';
 import Reaction from '../../common/Reaction/Reaction';
-import { useCreateRejectedAnswer, useQuestionDelete } from '../../../hooks/useQuestion';
+import { DataChangeDetectionContext } from '../../../contexts/DataChangeDetectionContext';
 import { axiosBaseURL } from '../../../apis/axiosBaseURL';
 
 import styles from './FeedCard.module.css';
@@ -15,41 +15,47 @@ export default function FeedCard({ data }) {
   const { id: subjectId } = useContext(SubjectDataContext);
   const isId = localStorage.getItem('id') == subjectId;
 
+  const setDataChangeDetection = useContext(DataChangeDetectionContext);
+
   // Kebab
   const noAnswerList = ['답변거절'];
   const answerList = ['수정하기', '삭제하기'];
 
-  //
+  // 수정
   const [editCheck, setEditCheck] = useState(false);
 
   const handleButtonClick = async (e) => {
     if (e.target.innerText === '수정하기') {
       setEditCheck(true);
-
-      // 컴포넌트 호출
-      console.log(e.target.innerText);
     }
 
     if (e.target.innerText === '삭제하기') {
-      await useQuestionDelete(`questions/${id}/`);
+      try {
+        await axiosBaseURL.delete(`questions/${id}/`);
+        setDataChangeDetection(true);
+      } catch (error) {
+        console.log(`handleButtonClick 삭제하기 Error : ${error}`);
+      }
     }
 
     if (e.target.innerText === '답변거절') {
-      // 커스텀 훅으로 사용하고싶으나 405error발생 : 수정필요
-      // useCreateRejectedAnswer(`questions/${id}/answers/`);
-
-      await axiosBaseURL.post(
-        `questions/${id}/answers/`,
-        {
-          content: 'isRejected',
-          isRejected: true,
-        },
-        {
-          headers: {
-            'Content-Type': 'application/json',
+      try {
+        await axiosBaseURL.post(
+          `questions/${id}/answers/`,
+          {
+            content: 'isRejected',
+            isRejected: true,
           },
-        }
-      );
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+        setDataChangeDetection(true);
+      } catch (error) {
+        console.log(`handleButtonClick 답변거절 Error : ${error}`);
+      }
     }
   };
 
@@ -60,8 +66,9 @@ export default function FeedCard({ data }) {
         {isId && <DropdownKebab handleButtonClick={handleButtonClick} list={answer ? answerList : noAnswerList} />}
       </div>
       <Question createdAt={createdAt} content={content} />
-      {answer && <AnswerMain editCheck={editCheck} questionId={id} answer={answer} />}
+      {answer && <AnswerMain editCheck={editCheck} questionId={id} answer={answer} setEditCheck={setEditCheck} />}
       <Reaction id={id} like={like} dislike={dislike} />
     </div>
   );
 }
+z;

--- a/src/components/postpage/MainSection/MainSection.jsx
+++ b/src/components/postpage/MainSection/MainSection.jsx
@@ -54,28 +54,36 @@ export default function MainSection() {
     setModalOpen(true);
   };
 
-  // 전체 삭제 : api ?
+  // 전체 삭제 : 404에러발생 ?
   const handleDeleteButton = async () => {
-    // api ?
+    console.log(id);
+    try {
+      await axiosBaseURL.delete(`subjects/${id}/`);
+      setDataChangeDetection(true);
+    } catch (error) {
+      console.log(`handleDeleteButton Error : ${error}`);
+    }
   };
 
   return (
     <div className={styles.mainSection}>
-      <div className={styles.questionBox}>
-        {isId && (
-          <ButtonFloating handleButtonClick={handleDeleteButton} text='삭제하기' className={styles.deleteButton} />
+      <DataChangeDetectionContext.Provider value={setDataChangeDetection}>
+        <div className={styles.questionBox}>
+          {isId && (
+            <ButtonFloating handleButtonClick={handleDeleteButton} text='삭제하기' className={styles.deleteButton} />
+          )}
+          <QuestionBox newData={newData} />
+        </div>
+        {!isId && (
+          <ButtonFloating
+            className={styles.askQuestionButton}
+            handleButtonClick={handleShowModal}
+            text={isMobilSize ? `질문 작성` : `질문 작성하기`}
+          />
         )}
-        <QuestionBox newData={newData} />
-      </div>
-      {!isId && (
-        <ButtonFloating
-          className={styles.askQuestionButton}
-          handleButtonClick={handleShowModal}
-          text={isMobilSize ? `질문 작성` : `질문 작성하기`}
-        />
-      )}
 
-      {modalOpen && <Modal setNewData={setNewData} setModalOpen={setModalOpen} />}
+        {modalOpen && <Modal setNewData={setNewData} setModalOpen={setModalOpen} />}
+      </DataChangeDetectionContext.Provider>
     </div>
   );
 }

--- a/src/hooks/useQuestion.js
+++ b/src/hooks/useQuestion.js
@@ -35,3 +35,8 @@ export const useCreateRejectedAnswer = async (url) => {
 export const useQuestionDelete = async (url) => {
   axiosBaseURL.delete(url);
 };
+
+// 전체 질문 삭제
+export const useQuestionDeleteAll = async (url) => {
+  axiosBaseURL.delete(url);
+};

--- a/src/pages/answer/AnswerPage.jsx
+++ b/src/pages/answer/AnswerPage.jsx
@@ -3,8 +3,9 @@ import { SubjectDataContext } from '../../contexts/SubjectDataContext';
 import { useGetData } from '../../hooks/useGetData';
 import MainSection from '../../components/postpage/MainSection/MainSection';
 import Header from '../../components/page-layout/QuestionPage/Layout/Header';
+import styles from './AnswerPage.module.css';
 
-export default function PostPage() {
+export default function AnswerPage() {
   const { id } = useParams();
   const url = `subjects/${id}/`;
   const { data, loading } = useGetData(url);
@@ -13,7 +14,7 @@ export default function PostPage() {
   }
 
   return (
-    <div>
+    <div className={styles.answerPage}>
       <SubjectDataContext.Provider value={data}>
         <Header />
         <MainSection />

--- a/src/pages/answer/AnswerPage.module.css
+++ b/src/pages/answer/AnswerPage.module.css
@@ -1,0 +1,5 @@
+.answerPage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}


### PR DESCRIPTION
### 주요 변경 사항
- 전체 삭제  : subject 삭제 되도록 수정 
- 요청 이후 브라우저에 새로운 데이터 렌더링 작업(id삭제, 답변하기, 수정하기 등)
- kebab(수정하기) : 수정하기 버튼을 클릭하면 id에 해당하는 폼이 수정폼으로 변경되도록 구현
- 로컬스토리지 여부로 postPage, answerPage 구분
- 현재 PR에서 FeeCard 오타가 발생하여 수정해두었습니다.#39 

### 스크린샷
Answer (로컬스토리지O)
 - 현재 PR에서 answerPage를 보여줄 때 `isId`가아닌 `answer`로 설정해두어 Form이 제대로 안보입니다.
 이후 PR에서 수정해서 반영해두겠습니다. #40 
![image](https://github.com/SprintPart2Team10/openmind/assets/43229599/89072c28-94ba-472f-917a-73a1c03dd4b4)
Post (로컬스토리지X)
 ![image](https://github.com/SprintPart2Team10/openmind/assets/43229599/0a0de05a-64ef-4a78-97cc-ba3a19b8682e)

### 문제


 추가 기능구현이 필요한 부분입니다.
- 전체 삭제  : 전체삭제 이후 재렌더와, undifind로 화면이 보이는데 수정이 필요해보입니다.
- CSS : 수정이 필요한 내용 확인




